### PR TITLE
Add client-side form validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.4",
         "zod": "^3.25.20"
       },
       "devDependencies": {
@@ -5075,6 +5076,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
+      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.4",
     "zod": "^3.25.20"
   },
   "devDependencies": {

--- a/src/app/form.tsx
+++ b/src/app/form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { startTransition, useActionState, useRef } from "react";
+import { useForm, SubmitHandler } from "react-hook-form"
+
+import { checkPostcode } from "./actions";
+import { TextInput } from "@/components/ui/text-input";
+import { WarningIcon } from "@/components/icons/warning";
+import { Button } from "@/components/ui/button";
+
+type FormValues = {
+  postcode: string;
+}
+
+const initialState = {
+  message: "",
+};
+
+export function Form() {
+  const [state, formAction, isPending] = useActionState(checkPostcode, initialState);
+  const ref = useRef<HTMLFormElement>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+   } = useForm<FormValues>();
+
+  const onSubmit: SubmitHandler<FormValues> = () => {
+    startTransition(() => {
+      const formData = new FormData(ref.current as HTMLFormElement);
+      formAction(formData);
+    });
+  };
+
+  return (
+    <form action={formAction} onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4 mb-8" ref={ref}>
+      <div className="flex flex-col gap-2 my-4">
+        <label htmlFor="postcode" className="text-md font-semibold">Postcode</label>
+        {(state.message || errors.postcode?.message) && !isPending && (
+          <div className="flex items-center gap-2">
+            <WarningIcon fill="var(--color-red-700)" aria-hidden={true} focusable={false} />
+            <output name="status" htmlFor="postcode" >
+              <span>{errors.postcode?.message || state.message}</span>
+            </output>
+          </div>
+        )}
+        <TextInput
+          type="text"
+          id="postcode"
+          // We need to duplicate 'name' for progressive enhancement
+          //@ts-expect-error
+          name="postcode"
+          autoComplete="shipping postal-code"
+          hasError={!!state.message || !!errors.postcode?.message}
+          {...register("postcode", {
+            required: "Postcode is required",
+            pattern: {
+              value: /^[a-zA-Z\d]+ ?[a-zA-Z\d]+$/,
+              message: "Your postcode must be a valid UK postcode."
+            },
+          })}
+        />
+      </div>
+      <p>We&apos;ll also use your postcode to find your delivery address.</p>
+
+      <div className="flex gap-4 py-6 px-8 mx-auto rounded-3xl bg-gray-300 mb-8">
+        <div className="flex-shrink-0 relative w-12 h-12 m-0 p-0 flex items-center justify-center bg-white rounded-full">
+          <WarningIcon aria-hidden={true} focusable={false} />
+          <span className="sr-only">Attention: </span>
+        </div>
+        <p className="text-md dark:text-gray-900">We cannot deliver to pick-up locations like InPost or OOHPod lockers or Post Offices.</p>
+      </div>
+
+      <hr className="my-3" />
+
+      <Button isLoading={isPending} className="ml-auto" />
+    </form>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,6 @@
-"use client";
-
-import { useActionState } from "react";
-import { checkPostcode } from "./actions";
-import { TextInput } from "@/components/ui/text-input";
-import { WarningIcon } from "@/components/icons/warning";
-import { Button } from "@/components/ui/button";
+import { Form } from "./form";
 
 export default function Home() {
-  const [state, formAction, isPending] = useActionState(checkPostcode, initialState);
-
   return (
     <>
       <h2 className="text-xl mb-3 font-semibold">
@@ -18,35 +10,7 @@ export default function Home() {
         We&apos;re funded to deliver free services in areas across the UK. We work with local commissioners to decide what to offer in different places. Enter your postcode to see if you&apos;re eligible for our services.
       </p>
 
-      <form action={formAction} className="flex flex-col gap-4 mb-8">
-        <div className="flex flex-col gap-2 my-4">
-          <label htmlFor="postcode" className="text-md font-semibold">Postcode</label>
-          {state.message && !isPending && (
-            <div className="flex items-center gap-2">
-              <WarningIcon fill="var(--color-red-700)" aria-hidden={true} focusable={false}/>
-              <output name="status" htmlFor="postcode" >
-                <span>{state.message}</span>
-              </output>
-            </div>
-          )}
-          <TextInput type="text" id="postcode" name="postcode" autoComplete="shipping postal-code" hasError={!!state.message} />
-        </div>
-        <p>We&apos;ll also use your postcode to find your delivery address.</p>
-
-        <div className="flex gap-4 py-6 px-8 mx-auto rounded-3xl bg-gray-300 mb-8">
-          <div className="flex-shrink-0 relative w-12 h-12 m-0 p-0 flex items-center justify-center bg-white rounded-full">
-            <WarningIcon aria-hidden={true} focusable={false} />
-            <span className="sr-only">Attention: </span>
-          </div>
-          <p className="text-md dark:text-gray-900">We cannot deliver to pick-up locations like InPost or OOHPod lockers or Post Offices.</p>
-        </div>
-        <hr className="my-3" />
-        <Button isLoading={isPending} className="ml-auto"/>
-      </form>
+      <Form />
     </>
   );
 }
-
-const initialState = {
-  message: "",
-};


### PR DESCRIPTION
Adds simple progressive enhancement for client-side form validation using [React Hook Form](https://react-hook-form.com/).

In a production environment, you could use a more complete solution like [shadcn Form](https://ui.shadcn.com/docs/components/form) with a Zod resolver.